### PR TITLE
fix(kernel/cursor): ensure that the cursor position is correctly synchronized

### DIFF
--- a/src/x86/kernel.c
+++ b/src/x86/kernel.c
@@ -31,5 +31,6 @@ void kernel_main()
         console_write_string("\n");
     }
 
-    console_write_string("bye\n");
+    display_set_cursor_position(0, VGA_HEIGHT - 1);
+    console_write_string("bye");
 }

--- a/src/x86/terminal/print.c
+++ b/src/x86/terminal/print.c
@@ -72,6 +72,22 @@ static void vga_enable_cursor(const uint8_t cursor_start, const uint8_t cursor_e
 }
 
 /**
+ * Updates the cursor position on the VGA text-mode display.
+ */
+static void vga_update_cursor_position(void)
+{
+    const uint16_t pos = (g_cursor_row * VGA_WIDTH) + g_cursor_column;
+
+    if (pos >= VGA_WIDTH * VGA_HEIGHT)
+        return;
+
+    io_outb(0x3D4, 0x0F);
+    io_outb(0x3D5, pos & 0xFF);
+    io_outb(0x3D4, 0x0E);
+    io_outb(0x3D5, (pos >> 8) & 0xFF);
+}
+
+/**
  * Clears a single line on the display by writing blank characters with the
  * default background and foreground colors.
  *
@@ -160,19 +176,17 @@ void display_clear(void)
 }
 
 /**
- * Updates the position of the hardware text mode cursor.
- *
- * @param x The column position of the cursor.
- * @param y The row position of the cursor.
+ * Sets the cursor position on the display.
  */
-void display_set_cursor_position(const unsigned x, const unsigned y)
+int display_set_cursor_position(const unsigned x, const unsigned y)
 {
-    const uint16_t pos = y * VGA_WIDTH + x;
+    if (x >= VGA_WIDTH || y >= VGA_HEIGHT)
+        return -1;
 
-    io_outb(0x3D4, 0x0F);
-    io_outb(0x3D5, pos & 0xFF);
-    io_outb(0x3D4, 0x0E);
-    io_outb(0x3D5, (pos >> 8) & 0xFF);
+    g_cursor_column = x;
+    g_cursor_row = y;
+    vga_update_cursor_position();
+    return 0;
 }
 
 /**
@@ -185,7 +199,7 @@ void display_initialize(void)
     g_cursor_column = 0;
     display_clear();
     vga_enable_cursor(14, 15);
-    display_set_cursor_position(0, 0);
+    vga_update_cursor_position();
 }
 
 /**
@@ -196,7 +210,7 @@ void console_write_string(const char* str)
     const size_t len = string_length(str);
     for (size_t i = 0; i < len; i++)
         display_put_char(str[i], DEFAULT_TEXT_COLORS);
-    display_set_cursor_position(g_cursor_column, g_cursor_row);
+    vga_update_cursor_position();
 }
 
 /**
@@ -211,7 +225,7 @@ void console_write_uint(const unsigned value)
     if (value == 0)
     {
         display_put_char('0', DEFAULT_TEXT_COLORS);
-        display_set_cursor_position(g_cursor_column, g_cursor_row);
+        vga_update_cursor_position();
         return;
     }
 
@@ -225,7 +239,7 @@ void console_write_uint(const unsigned value)
     // Display the numbers in the correct order
     while (pos > 0)
         display_put_char(buffer[--pos], DEFAULT_TEXT_COLORS);
-    display_set_cursor_position(g_cursor_column, g_cursor_row);
+    vga_update_cursor_position();
 }
 
 /**

--- a/src/x86/terminal/print.h
+++ b/src/x86/terminal/print.h
@@ -53,12 +53,13 @@ typedef struct
 void display_clear(void);
 
 /**
- * @brief Updates the cursor position on the screen.
+ * @brief Sets the cursor position on the display.
  *
- * @param x The horizontal position of the cursor in character cells.
- * @param y The vertical position of the cursor in character cells.
+ * @param x The horizontal position of the cursor (0-based index).
+ * @param y The vertical position of the cursor (0-based index).
+ * @return 0 if the cursor position is successfully set, or -1 if the position is out of bounds.
  */
-void display_set_cursor_position(const unsigned x, const unsigned y);
+int display_set_cursor_position(const unsigned x, const unsigned y);
 
 /**
  * @brief Initializes the terminal for printing


### PR DESCRIPTION
This commit fixes a bug in `display_set_cursor_position` where the cursor wasn't handled correctly.
Previously, the display cursor would update but the internal position wasn't synchronized, causing issues when performing operations after updating the cursor position.

Changes include:
- Updated `display_set_cursor_position` to return an error code for out-of-bounds positions
- Introduced `vga_update_cursor_position` to handle low-level VGA cursor updates, improving code clarity and reuse
- Adjusted related functions to utilize the new helper function