### PR TITLE
docs(kernel): new documentation for kernel startup and display operations

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,14 @@ The `x86` folder provides detailed information specific to the x86 architecture.
 Detailed information about how FunOS boots on x86 architecture can be found in
 the [boot sequence documentation](x86/boot.md).
 
+### Kernel Startup
+
+The requirements and setup done by FunOS during startup can be found in the [kernel_startup](x86/kernel_startup.md) doc.
+
+### Display
+
+For details about how to print messages on the screen, see the [display](x86/display.md) doc.
+
 # Learning docs
 
 The **learning folder** contains a compilation of information that I use to build **FunOS**.

--- a/docs/x86/display.md
+++ b/docs/x86/display.md
@@ -1,0 +1,13 @@
+# Display
+
+In FunOs, you have access to three functions for printing data to the screen `console_write_<string, uint, int>`.
+To use them import `#include <terminal/print.h>` in your code.
+
+You can also clear the terminal screen with `display_clear`.
+
+If needed, you can update the current cursor position with `display_set_cursor_position`.
+After calling this function, all writing to the console starts at the specified position.
+
+Note that in some cases if a bug occurs in the internal of terminal functions with position, FunOs will
+quietly discard the character output or cursor position update.
+This is to ensure that it doesn't write anything to out-of-range video memory space.

--- a/docs/x86/kernel_startup.md
+++ b/docs/x86/kernel_startup.md
@@ -1,0 +1,23 @@
+# Kernel Startup
+
+The first function that the bootloader must call is `_start` in `kernel.asm`.
+This function ensures that A20 and segment registers are set up correctly.
+
+Note that FunOs assumes that:
+
+- Entry 0x08 in GDT is code segment and 0x10 is data segment.
+- The processor is already in protected mode.
+
+After `_start` has setup the environment, it calls `kernel_main` in `kernel.c`.
+The `kernel_main` calls `idt_initialize` and `display_initialize` to complete the setup of FunOs.
+
+## IDT
+
+The `idt_initialize` function sets up basic handlers for x86 interruption numbers 0 to 30.
+When an interruption is triggered, the handler prints a message corresponding to the interruption in the screen.
+If it is an exception interruption, the handler prints a kernel panic message and stops the kernel execution.
+
+## Display
+
+The `display_initialize` function sets up the VGA text mode and clears all content shown on screen.
+After that kernel developers can use `console_write` functions to print messages in the screen.


### PR DESCRIPTION
This pull request adds two new documentation files: `kernel_startup.md` and `display.md`. 
- `kernel_startup.md` details the initialization steps of the kernel in FunOS.
- `display.md` describes the available display functions and their usages.

Additionally, relevant references to these documentation files were added to the `README.md` for improved navigation.
