### PR TITLE
 feat(kernel/PIC): keyboard interrupt support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,5 +82,5 @@ that I need to keep in mind for reference.
 
 ### PIC (Programmable Interrupt Controller)
 
-- **[PIC](learning/pic.md)**: Hardware component in computer systems that manages hardware interrupt requests (IRQs) and
-  prioritizes them before sending to the CPU.
+- **[PIC](learning/x86/pic.md)**: Hardware component in computer systems that manages hardware interrupt requests (IRQs)
+  and prioritizes them before sending to the CPU.

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,3 +79,8 @@ that I need to keep in mind for reference.
 
 - **[IN And OUT](learning/x86/io_port.md)** : I/O port used for communication between the processor and peripheral
   devices.
+
+### PIC (Programmable Interrupt Controller)
+
+- **[PIC](learning/pic.md)**: Hardware component in computer systems that manages hardware interrupt requests (IRQs) and
+  prioritizes them before sending to the CPU.

--- a/docs/learning/x86/pic.md
+++ b/docs/learning/x86/pic.md
@@ -1,0 +1,77 @@
+# PIC (Programmable Interrupt Controller)
+
+The PIC (Programmable Interrupt Controller) is a crucial hardware part in computers that manages IRQs (Interrupt
+Requests).
+Its goal is to allow various devices to interrupt the processor without requiring constant polling of device status.
+The main function of the PIC is prioritizing and managing the interrupts it receives.
+When interrupts is allowed, PIC signals the processor to pause its current task and execute the appropriate ISR (
+Interrupt Service Routine).
+
+As computer hardware evolved and required more than 8 interrupt lines, systems began to include two PICs, referred to as
+the "master" and "slave" PICs, connected together in a cascading configuration.
+This arrangement increased the available interrupt lines from 8 to 15 (with one line used for communication between the
+PICs).
+
+In terms of programming, the PIC can be configured to:
+
+- Ignore specific interrupts
+- Change interrupt priorities
+- Remap interrupt numbers
+
+However, the PIC has been largely superseded in modern systems by the APIC (Advanced Programmable Interrupt Controller)
+and newer IO-APIC, which offers better performance and more functionality, especially in multiprocessor systems.
+
+## PIC Communication
+
+The communication with the PIC is achieved through I/O ports:
+
+- **Master PIC**: 0x20 (command port) and 0x21 (data port)
+- **Slave PIC**: 0xA0 (command port) and 0xA1 (data port)
+
+Basic commands for PIC setup include:
+
+- **ICW (Initialization Command Word)** sequence: Used for initial configuration of the PIC
+- **EOI (End of Interrupt)** command: Signals to the PIC that the interrupt handling is complete, and it can resume
+  sending interrupts
+
+## Typical IRQ Assignments in Traditional PC Systems
+
+- **IRQ0**: System timer - Used by the system's internal timer or clock
+- **IRQ1**: Keyboard controller - Signaled whenever a key is pressed or released on the keyboard
+- **IRQ2**: Cascade to the second PIC - Functions as a link between the two PICs
+- **IRQ3**: COM2/COM4 serial ports
+- **IRQ4**: COM1/COM3 serial ports
+- **IRQ5**: LPT2 parallel port or sound card
+- **IRQ6**: Floppy disk controller
+- **IRQ7**: LPT1 parallel port (also known as the printer port)
+- **IRQ8**: Real-time clock (RTC) on the motherboard
+- **IRQ9**: General configuration or software redirection - Can be used for legacy hardware support
+- **IRQ10**: General configuration (similar to IRQ9)
+- **IRQ11**: General configuration (similar to IRQ9)
+- **IRQ12**: Mouse on PS/2 connectors
+- **IRQ13**: Math co-processor (also known as the Floating Point Unit or FPU)
+- **IRQ14**: Primary ATA channel (IDE) hard disk controller
+- **IRQ15**: Secondary ATA channel
+
+## Example of Key Press Event Processing
+
+1) A key press is registered by the keyboard hardware, which generates a signal corresponding to the key pressed and
+   sends it to the keyboard controller on the motherboard.
+
+2) The keyboard controller receives the signal, translates it into a scancode, and signals an interrupt request to the
+   PIC using the IRQ1 line.
+
+3) The PIC receives and processes the interrupt request on IRQ1. If no higher priority interrupts are being serviced,
+   the PIC sends the current keyboard interrupt to the processor via the INTR line.
+
+4) The processor suspends its current operation and starts executing the ISR (Interrupt Service Routine), which is
+   defined in the IDT (Interrupt Descriptor Table) and points to the address of the function that handles key presses.
+
+5) The ISR for the keyboard reads the scancode from the keyboard controller's data buffer and translates it into the
+   appropriate character. If necessary, it updates the system state for further processing.
+
+6) Once the ISR has processed the keystroke, it signals the End of Interrupt (EOI) to the PIC, which allows the
+   processor to resume its previous operation.
+
+7) When the key is released, a similar sequence occurs, allowing the system to recognize that the key is no longer being
+   pressed.

--- a/docs/learning/x86/pic.md
+++ b/docs/learning/x86/pic.md
@@ -75,3 +75,28 @@ Basic commands for PIC setup include:
 
 7) When the key is released, a similar sequence occurs, allowing the system to recognize that the key is no longer being
    pressed.
+
+## Why Remap the PIC?
+
+The PIC (Programmable Interrupt Controller), by default, maps its interrupts starting at 0, which overlaps with the CPU
+exception handlers set in the IDT (Interrupt Descriptor Table) for the first 32 interrupts (0 to 31).
+To avoid this conflict, we need to remap the PIC so that its interrupts start from 32 (0x20).
+This ensures that there is no confusion between CPU exceptions and device interrupts.
+
+The remapping is done by sending ICW (Initialization Control Word) commands to the PIC:
+
+1) **Start Initialization**: Send ICW1 to the command port of both PICs.
+
+2) **Define the Vector Offset**: Send ICW2 to the data port of both PICs.
+   This specifies the starting interrupt number that the PIC should use for its interrupts.
+   Typically, the master PIC is set with 32 (0x20) and the slave PIC is set with 40 (0x28).
+
+3) **Define the Cascade**: Send ICW3 to the data port of both PICs.
+   This informs the master PIC about the presence of the slave PIC and tells the identity of the slave PIC.
+
+4) **Environment Information**: Send ICW4 to the data port of both PICs.
+   This provides additional information to the PICs about the environment in which they are operating.
+
+5) **End Initialization**: After the ICWs have been set, the PICs are ready to handle interrupts.
+
+After remapping the PIC, all Interrupt Service Routines (ISRs) will add the new offset to their interrupt number.

--- a/docs/x86/kernel_startup.md
+++ b/docs/x86/kernel_startup.md
@@ -2,6 +2,7 @@
 
 The first function that the bootloader must call is `_start` in `kernel.asm`.
 This function ensures that A20 and segment registers are set up correctly.
+After that, it sets up the master PIC with interrupt offset 0x20 to enable it to handle interrupts.
 
 Note that FunOs assumes that:
 
@@ -14,8 +15,9 @@ The `kernel_main` calls `idt_initialize` and `display_initialize` to complete th
 ## IDT
 
 The `idt_initialize` function sets up basic handlers for x86 interruption numbers 0 to 30.
-When an interruption is triggered, the handler prints a message corresponding to the interruption in the screen.
-If it is an exception interruption, the handler prints a kernel panic message and stops the kernel execution.
+It also sets up handlers for PIC IRQ 1: Keyboard controller interrupt.
+
+Note that if it is an exception interruption, the handler prints a kernel panic message and stops the kernel execution.
 
 ## Display
 

--- a/src/x86/idt/idt.asm
+++ b/src/x86/idt/idt.asm
@@ -1,7 +1,9 @@
 section .asm
 
-extern handle_keyboard_interrupt
 extern handler_no_interrupt
+extern handle_kernel_panic
+extern handle_keyboard_interrupt
+
 
 ; This function loads the address of an Interrupt Descriptor Table (IDT) into the CPU using the `lidt` instruction.
 ; The first argument to the function should be a pointer to the IDT structure.
@@ -20,25 +22,6 @@ idt_load_table:
     pop ebp
     ret
 
-; This function serves as the entry point for keyboard interrupts and calls the C implementation
-; handle_keyboard_interrupt().
-global idt_handle_keyboard_interrupt
-idt_handle_keyboard_interrupt:
-    ; Disable interrupts.
-    cli
-    ; Push all general-purpose registers.
-    ; The pushad instruction quickly saves the entire CPU register state so that the interrupt handler doesn't corrupt
-    ; the interrupted program's execution context.
-    pushad
-    ; Call the C/C++ handler function.
-    call handle_keyboard_interrupt
-    ; Restore all general-purpose registers.
-    popad
-    ; Enable interrupts.
-    sti
-    ; Return from interrupt
-    iret
-
 ; This function is used as the default handler for interrupts without specific handlers and calls the C
 ; implementation handler_no_interrupt().
 global idt_no_interrupt
@@ -56,4 +39,25 @@ idt_no_interrupt:
     ; Enable interrupts.
     sti
     ; Return from interrupt
+    iret
+
+; This function serves as the entry point for keyboard interrupts and calls the C implementation
+; handle_keyboard_interrupt().
+global idt_handle_keyboard_interrupt
+idt_handle_keyboard_interrupt:
+    cli
+    pushad
+    call handle_keyboard_interrupt
+    popad
+    sti
+    iret
+
+; This function serves as the entry point for x86 exception and calls C implementation handle_kernel_panic().
+global idt_handle_kernel_panic
+idt_handle_kernel_panic:
+    cli
+    pushad
+    call handle_kernel_panic
+    popad
+    sti
     iret

--- a/src/x86/idt/idt.asm
+++ b/src/x86/idt/idt.asm
@@ -1,5 +1,8 @@
 section .asm
 
+extern handle_keyboard_interrupt
+extern handler_no_interrupt
+
 ; This function loads the address of an Interrupt Descriptor Table (IDT) into the CPU using the `lidt` instruction.
 ; The first argument to the function should be a pointer to the IDT structure.
 global idt_load_table
@@ -16,3 +19,41 @@ idt_load_table:
     ; Restore the previous base pointer and clean up the stack frame.
     pop ebp
     ret
+
+; This function serves as the entry point for keyboard interrupts and calls the C implementation
+; handle_keyboard_interrupt().
+global idt_handle_keyboard_interrupt
+idt_handle_keyboard_interrupt:
+    ; Disable interrupts.
+    cli
+    ; Push all general-purpose registers.
+    ; The pushad instruction quickly saves the entire CPU register state so that the interrupt handler doesn't corrupt
+    ; the interrupted program's execution context.
+    pushad
+    ; Call the C/C++ handler function.
+    call handle_keyboard_interrupt
+    ; Restore all general-purpose registers.
+    popad
+    ; Enable interrupts.
+    sti
+    ; Return from interrupt
+    iret
+
+; This function is used as the default handler for interrupts without specific handlers and calls the C
+; implementation handler_no_interrupt().
+global idt_no_interrupt
+idt_no_interrupt:
+     ; Disable interrupts.
+    cli
+    ; Push all general-purpose registers.
+    ; The pushad instruction quickly saves the entire CPU register state so that the interrupt handler doesn't corrupt
+    ; the interrupted program's execution context.
+    pushad
+    ; Call the C/C++ handler function.
+    call handler_no_interrupt
+    ; Restore all general-purpose registers.
+    popad
+    ; Enable interrupts.
+    sti
+    ; Return from interrupt
+    iret

--- a/src/x86/idt/idt.c
+++ b/src/x86/idt/idt.c
@@ -7,12 +7,18 @@
 #include "config.h"
 #include "memory/memory.h"
 #include <terminal/print.h>
+#include <io/io.h>
 
 static struct idt_entry g_idt_entries[FUNOS_TOTAL_INTERRUPTS];
 static struct idt_pointer g_idt_pointer;
 
 // Function to load the IDT into the CPU (implemented in assembly).
 extern void idt_load_table(struct idt_pointer* ptr);
+
+// Assembly interrupt handler for keyboard events.
+extern void idt_handle_keyboard_interrupt(void);
+// Default assembly interrupt handler for unhandled interrupts.
+extern void idt_no_interrupt(void);
 
 /**
  * Divide by zero exception handlers.
@@ -304,6 +310,31 @@ static void idt_handle_security_exception(void)
     while (1);
 }
 
+/**
+ * Keyboard interrupt handler.
+ * This function processes keyboard input by outputs the scancode to the console.
+ */
+void handle_keyboard_interrupt(void)
+{
+    // Get keycode from keyboard controller.
+    const uint8_t keycode = io_inb(0x60);
+
+    console_write_uint(keycode);
+    console_write_string("\n");
+
+    // Tell the PIC that we have handled the interrupt.
+    io_outb(PIC1_COMMAND, PIC_EOI);
+}
+
+/**
+ * Handles spurious or unused interrupts.
+ * This function acts as a default handler for interrupts that don't require specific processing.
+ */
+void handler_no_interrupt(void)
+{
+    // Tell the PIC that we have handled the interrupt.
+    io_outb(PIC1_COMMAND, PIC_EOI);
+}
 
 /**
  * Maps an interrupt number to a handler function (address).
@@ -346,6 +377,10 @@ void idt_initialize(void)
     // Cast the descriptor array pointer to uint32_t for proper storage.
     g_idt_pointer.base = (uint32_t)g_idt_entries;
 
+    // Set default interrupt handler.
+    for (int i = 0; i < FUNOS_TOTAL_INTERRUPTS; i++)
+        idt_register_handler(i, idt_no_interrupt);
+
     /**
        * Maps standard CPU interrupts to their respective handlers.
        * This sets up handlers for all standard x86 exceptions (interrupts 0-31),
@@ -376,6 +411,11 @@ void idt_initialize(void)
     idt_register_handler(HYPERVISOR_INJECTION_EXCEPTION, idt_handle_hypervisor_injection_exception);
     idt_register_handler(VMM_COMMUNICATION_EXCEPTION, idt_handle_vmm_communication_exception);
     idt_register_handler(SECURITY_EXCEPTION, idt_handle_security_exception);
+
+    /*
+     * Maps standard PIC interrupts to their respective handlers.
+     */
+    idt_register_handler(KEYBOARD_INTERRUPT, idt_handle_keyboard_interrupt);
 
     // Load the IDT into the processor using the assembly function.
     idt_load_table(&g_idt_pointer);

--- a/src/x86/idt/idt.c
+++ b/src/x86/idt/idt.c
@@ -15,299 +15,23 @@ static struct idt_pointer g_idt_pointer;
 // Function to load the IDT into the CPU (implemented in assembly).
 extern void idt_load_table(struct idt_pointer* ptr);
 
-// Assembly interrupt handler for keyboard events.
-extern void idt_handle_keyboard_interrupt(void);
 // Default assembly interrupt handler for unhandled interrupts.
 extern void idt_no_interrupt(void);
 
-/**
- * Divide by zero exception handlers.
- * This function is called when a divide-by-zero error occurs.
- */
-static void idt_handle_division_zero(void)
-{
-    console_write_string("Kernel interrupt: divide by zero interrupt occurs.\n");
-    console_write_string("Kernel panic!\n");
-    while (1);
-}
+// Assembly interrupt handler for x86 exception.
+extern void idt_handle_kernel_panic(void);
+
+// Assembly interrupt handler for keyboard events.
+extern void idt_handle_keyboard_interrupt(void);
 
 /**
- * Debug interrupt handler.
- * This function is called when a debug interrupt occurs.
- * Kernel execution continues after this interrupt.
+ * Handles spurious or unused interrupts.
+ * This function acts as a default handler for interrupts that don't require specific processing.
  */
-static void idt_handle_debug(void)
+void handler_no_interrupt(void)
 {
-    console_write_string("Kernel interrupt: debug interrupt occurs.");
-    console_write_string("Kernel skip idt");
-}
-
-/**
- * Non-maskable interrupt handler.
- * This function is called when a non-maskable interrupt (NMI) occurs.
- * Kernel execution continues after this interrupt.
- */
-static void idt_handle_non_maskable_interrupt(void)
-{
-    console_write_string("Kernel interrupt: non-maskable interrupt occurs.");
-    console_write_string("Kernel skip idt");
-}
-
-/**
- * Breakpoint interrupt handler.
- * This function is called when a breakpoint instruction is executed.
- * Kernel execution continues after this interrupt.
- */
-static void idt_handle_breakpoint(void)
-{
-    console_write_string("Kernel interrupt: breakpoint interrupt occurs.");
-    console_write_string("Kernel skip idt");
-}
-
-/**
- * Overflow interrupt handler.
- * This function is called when an arithmetic overflow occurs.
- * Kernel execution continues after this interrupt.
- */
-static void idt_handle_overflow(void)
-{
-    console_write_string("Kernel interrupt: overflow interrupt occurs.");
-    console_write_string("Kernel skip idt");
-}
-
-/**
- * Bound range exceeded interrupt handler.
- * This function is called when a BOUND instruction detects that an operand
- * exceeds the specified boundaries.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_bound_range_exceeded(void)
-{
-    console_write_string("Kernel interrupt: bound range interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * Invalid opcode interrupt handler.
- * This function is called when the processor attempts to execute an invalid instruction.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_invalid_opcode(void)
-{
-    console_write_string("Kernel interrupt: invalid opcode interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * Device not available interrupt handler.
- * This function is called when a coprocessor or extension is not available.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_device_not_available(void)
-{
-    console_write_string("Kernel interrupt: device not available interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * Double fault interrupt handler.
- * This function is called when an exception occurs during the handling
- * of a previous exception.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_double_fault(void)
-{
-    console_write_string("Kernel interrupt: double fault interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * Coprocessor segment overrun interrupt handler.
- * This function is called when a coprocessor exceeds a segment boundary.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_coprocessor_segment_overrun(void)
-{
-    console_write_string("Kernel interrupt: coprocessor segment overrun interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * Invalid TSS interrupt handler.
- * This function is called when there's an attempt to access an invalid TSS (Task State Segment).
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_invalid_tss(void)
-{
-    console_write_string("Kernel interrupt: invalid tss interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * Segment not present interrupt handler.
- * This function is called when there's an attempt to access a segment that is not present.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_segment_not_present(void)
-{
-    console_write_string("Kernel interrupt: segment not present interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * Stack segment fault interrupt handler.
- * This function is called when an operation exceeds the stack segment limits.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_stack_segment_fault(void)
-{
-    console_write_string("Kernel interrupt: stack segment fault interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * General protection fault interrupt handler.
- * This function is called when a protection violation occurs that is not
- * covered by other exceptions.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_general_protection_fault(void)
-{
-    console_write_string("Kernel interrupt: general protection fault interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * Page fault interrupt handler.
- * This function is called when a memory access error occurs in paged memory.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_page_fault(void)
-{
-    console_write_string("Kernel interrupt: page fault interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * x87 floating-point exception handler.
- * This function is called when a floating-point error occurs
- * on the x87 coprocessor.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_x87_floating_point_exception(void)
-{
-    console_write_string("Kernel interrupt: x87 floating point exception interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * Alignment check interrupt handler.
- * This function is called when a memory alignment error occurs.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_alignment_check(void)
-{
-    console_write_string("Kernel interrupt: alignment check interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * Machine check interrupt handler.
- * This function is called when a critical hardware error is detected by the processor.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_machine_check(void)
-{
-    console_write_string("Kernel interrupt: machine check interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * SIMD floating-point exception handler.
- * This function is called when a floating-point error occurs
- * on the SIMD units (SSE, AVX, etc.).
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_simd_floating_point_exception(void)
-{
-    console_write_string("Kernel interrupt: SIMD floating point exception interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * Virtualization exception handler.
- * This function is called when an error related to virtualization operations occurs.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_virtualization_exception(void)
-{
-    console_write_string("Kernel interrupt: virtualization exception interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * Control protection exception handler.
- * This function is called when a violation of control protection mechanisms occurs.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_control_protection_exception(void)
-{
-    console_write_string("Kernel interrupt: control protection exception interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * Hypervisor injection exception handler.
- * This function is called when an error related to interrupt injection
- * by the hypervisor occurs.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_hypervisor_injection_exception(void)
-{
-    console_write_string("Kernel interrupt: hypervisor injection exception interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * VMM communication exception handler.
- * This function is called when an error in communication with the
- * virtual machine monitor occurs.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_vmm_communication_exception(void)
-{
-    console_write_string("Kernel interrupt: vmm communication exception interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
-}
-
-/**
- * Security exception handler.
- * This function is called when a violation of processor security mechanisms occurs.
- * Causes a system halt (kernel panic).
- */
-static void idt_handle_security_exception(void)
-{
-    console_write_string("Kernel interrupt: security exception interrupt occurs.");
-    console_write_string("Kernel panic!");
-    while (1);
+    // Tell the PIC that we have handled the interrupt.
+    io_outb(PIC1_COMMAND, PIC_EOI);
 }
 
 /**
@@ -327,13 +51,13 @@ void handle_keyboard_interrupt(void)
 }
 
 /**
- * Handles spurious or unused interrupts.
- * This function acts as a default handler for interrupts that don't require specific processing.
+ * Kernel panic handler.
+ * This function is invoked when a kernel panic occurs upon an exception.
  */
-void handler_no_interrupt(void)
+void handle_kernel_panic(void)
 {
-    // Tell the PIC that we have handled the interrupt.
-    io_outb(PIC1_COMMAND, PIC_EOI);
+    console_write_string("Kernel panic!\n");
+    while (1);
 }
 
 /**
@@ -387,30 +111,30 @@ void idt_initialize(void)
        * which include hardware exceptions, faults, and traps that can occur
        * during normal system operation.
        */
-    idt_register_handler(DIVISION_BY_ZERO, idt_handle_division_zero);
-    idt_register_handler(DEBUG, idt_handle_debug);
-    idt_register_handler(NON_MASKABLE_INTERRUPT, idt_handle_non_maskable_interrupt);
-    idt_register_handler(BREAKPOINT, idt_handle_breakpoint);
-    idt_register_handler(OVERFLOW, idt_handle_overflow);
-    idt_register_handler(BOUND_RANGE_EXCEEDED, idt_handle_bound_range_exceeded);
-    idt_register_handler(INVALID_OPCODE, idt_handle_invalid_opcode);
-    idt_register_handler(DEVICE_NOT_AVAILABLE, idt_handle_device_not_available);
-    idt_register_handler(DOUBLE_FAULT, idt_handle_double_fault);
-    idt_register_handler(COPROCESSOR_SEGMENT_OVERRUN, idt_handle_coprocessor_segment_overrun);
-    idt_register_handler(INVALID_TSS, idt_handle_invalid_tss);
-    idt_register_handler(SEGMENT_NOT_PRESENT, idt_handle_segment_not_present);
-    idt_register_handler(STACK_SEGMENT_FAULT, idt_handle_stack_segment_fault);
-    idt_register_handler(GENERAL_PROTECTION_FAULT, idt_handle_general_protection_fault);
-    idt_register_handler(PAGE_FAULT, idt_handle_page_fault);
-    idt_register_handler(X87_FLOATING_POINT_EXCEPTION, idt_handle_x87_floating_point_exception);
-    idt_register_handler(ALIGNMENT_CHECK, idt_handle_alignment_check);
-    idt_register_handler(MACHINE_CHECK, idt_handle_machine_check);
-    idt_register_handler(SIMD_FLOATING_POINT_EXCEPTION, idt_handle_simd_floating_point_exception);
-    idt_register_handler(VIRTUALIZATION_EXCEPTION, idt_handle_virtualization_exception);
-    idt_register_handler(CONTROL_PROTECTION_EXCEPTION, idt_handle_control_protection_exception);
-    idt_register_handler(HYPERVISOR_INJECTION_EXCEPTION, idt_handle_hypervisor_injection_exception);
-    idt_register_handler(VMM_COMMUNICATION_EXCEPTION, idt_handle_vmm_communication_exception);
-    idt_register_handler(SECURITY_EXCEPTION, idt_handle_security_exception);
+    idt_register_handler(DIVISION_BY_ZERO, idt_handle_kernel_panic);
+    idt_register_handler(DEBUG, idt_no_interrupt);
+    idt_register_handler(NON_MASKABLE_INTERRUPT, idt_no_interrupt);
+    idt_register_handler(BREAKPOINT, idt_no_interrupt);
+    idt_register_handler(OVERFLOW, idt_no_interrupt);
+    idt_register_handler(BOUND_RANGE_EXCEEDED, idt_handle_kernel_panic);
+    idt_register_handler(INVALID_OPCODE, idt_handle_kernel_panic);
+    idt_register_handler(DEVICE_NOT_AVAILABLE, idt_handle_kernel_panic);
+    idt_register_handler(DOUBLE_FAULT, idt_handle_kernel_panic);
+    idt_register_handler(COPROCESSOR_SEGMENT_OVERRUN, idt_handle_kernel_panic);
+    idt_register_handler(INVALID_TSS, idt_handle_kernel_panic);
+    idt_register_handler(SEGMENT_NOT_PRESENT, idt_handle_kernel_panic);
+    idt_register_handler(STACK_SEGMENT_FAULT, idt_handle_kernel_panic);
+    idt_register_handler(GENERAL_PROTECTION_FAULT, idt_handle_kernel_panic);
+    idt_register_handler(PAGE_FAULT, idt_handle_kernel_panic);
+    idt_register_handler(X87_FLOATING_POINT_EXCEPTION, idt_handle_kernel_panic);
+    idt_register_handler(ALIGNMENT_CHECK, idt_handle_kernel_panic);
+    idt_register_handler(MACHINE_CHECK, idt_handle_kernel_panic);
+    idt_register_handler(SIMD_FLOATING_POINT_EXCEPTION, idt_handle_kernel_panic);
+    idt_register_handler(VIRTUALIZATION_EXCEPTION, idt_handle_kernel_panic);
+    idt_register_handler(CONTROL_PROTECTION_EXCEPTION, idt_handle_kernel_panic);
+    idt_register_handler(HYPERVISOR_INJECTION_EXCEPTION, idt_handle_kernel_panic);
+    idt_register_handler(VMM_COMMUNICATION_EXCEPTION, idt_handle_kernel_panic);
+    idt_register_handler(SECURITY_EXCEPTION, idt_handle_kernel_panic);
 
     /*
      * Maps standard PIC interrupts to their respective handlers.

--- a/src/x86/idt/idt.h
+++ b/src/x86/idt/idt.h
@@ -38,36 +38,69 @@ struct idt_pointer
 
 typedef enum : unsigned
 {
+    // CPU exception: Occurs when dividing by zero or when the result cannot be represented.
     DIVISION_BY_ZERO = 0,
+    // CPU exception: Raised when debugging conditions occur (e.g., hardware breakpoints).
     DEBUG = 1,
+    // Hardware interrupt: Cannot be disabled, typically signals critical hardware failures.
     NON_MASKABLE_INTERRUPT = 2,
+    // CPU exception: Triggered by INT3 instruction, used for software debugging.
     BREAKPOINT = 3,
+    // CPU exception: Result of an arithmetic operation is too large (INTO instruction).
     OVERFLOW = 4,
+    // CPU exception: BOUND instruction detects an index outside array boundaries.
     BOUND_RANGE_EXCEEDED = 5,
+    // CPU exception: Processor encounters an undefined opcode.
     INVALID_OPCODE = 6,
+    // CPU exception: Attempt to use FPU/MMX/SSE when not available.
     DEVICE_NOT_AVAILABLE = 7,
+    // CPU exception: Error occurs while handling another exception (serious system error).
     DOUBLE_FAULT = 8,
+    // CPU exception: Floating-point instruction exceeds segment limit (legacy 387 error).
     COPROCESSOR_SEGMENT_OVERRUN = 9,
+    // CPU exception: Invalid Task State Segment during task switch.
     INVALID_TSS = 10,
+    // CPU exception: Attempt to access segment marked as not present.
     SEGMENT_NOT_PRESENT = 11,
+    // CPU exception: Stack operation exceeds stack segment limit or segment not present.
     STACK_SEGMENT_FAULT = 12,
+    // CPU exception: General memory protection violation not covered by other exceptions.
     GENERAL_PROTECTION_FAULT = 13,
+    // CPU exception: Memory access violation in paged memory (absent/protection/rights).
     PAGE_FAULT = 14,
-    // 15 reserved.
+
+    // 15 reserved by Intel
+
+    // CPU exception: Floating-point error from x87 FPU (e.g., invalid operation).
     X87_FLOATING_POINT_EXCEPTION = 16,
+    // CPU exception: Unaligned memory access when alignment checking enabled.
     ALIGNMENT_CHECK = 17,
+    // CPU exception: CPU detected internal hardware error (may be non-recoverable).
     MACHINE_CHECK = 18,
+    // CPU exception: Error in SIMD floating-point operations (SSE/AVX).
     SIMD_FLOATING_POINT_EXCEPTION = 19,
+    // CPU exception: Error related to virtualization features (EPT violations).
     VIRTUALIZATION_EXCEPTION = 20,
+    // CPU exception: Control-flow enforcement technology (CET) violation.
     CONTROL_PROTECTION_EXCEPTION = 21,
-    // 22-27 reserved.
+
+    // 22-27 reserved by Intel.
+
+    // CPU exception: Hypervisor-injected exception in virtualized environment.
     HYPERVISOR_INJECTION_EXCEPTION = 28,
+    // CPU exception: Error in VM and VMM communication.
     VMM_COMMUNICATION_EXCEPTION = 29,
+    // CPU exception: Security-sensitive event in secure mode operation.
     SECURITY_EXCEPTION = 30,
-    // 31 est reserved
+
+    // 31 reserved by Intel.
+
+    // IRQ 0: Programmable Interval Timer (PIT) interrupt.
     TIMER_INTERRUPT = 32,
+    // IRQ 1: Keyboard controller interrupt.
     KEYBOARD_INTERRUPT = 33,
 } exception_vector_t;
+
 
 /**
  * @brief Initializes the Interrupt Descriptor Table (IDT).

--- a/src/x86/idt/idt.h
+++ b/src/x86/idt/idt.h
@@ -6,6 +6,13 @@
 #define IDT_H
 #include <stdint.h>
 
+// IO base address for master PIC.
+#define PIC1		0x20
+#define PIC1_COMMAND PIC1
+#define PIC1_DATA	(PIC1+1)
+
+// End-of-interrupt command code
+#define PIC_EOI		0x20
 
 #define IDT_OFFSET_LOW_MASK 0x0000FFFF
 #define IDT_OFFSET_HIGH_SHIFT 16
@@ -58,6 +65,8 @@ typedef enum : unsigned
     VMM_COMMUNICATION_EXCEPTION = 29,
     SECURITY_EXCEPTION = 30,
     // 31 est reserved
+    TIMER_INTERRUPT = 32,
+    KEYBOARD_INTERRUPT = 33,
 } exception_vector_t;
 
 /**

--- a/src/x86/kernel.asm
+++ b/src/x86/kernel.asm
@@ -28,7 +28,21 @@ _start:
     mov ebp, 0x00200000
     mov esp, ebp
 
-    call kernel_main
+    ; Remap the master PIC
+    ; ICW1
+    mov al, 00010001b
+    out 0x20, al;
+    ; ICW2 set the PIC offet to 0x20.
+    mov al, 0x20
+    out 0x21, al
+    ; ICW4
+    mov al, 00000001b
+    out 0x21, al;
+
+    ; Enable interrupts
+    sti
+
+    call CODE_SEG:kernel_main
 
     ; Do nothing more, enter an infinite loop.
     cli

--- a/src/x86/kernel.c
+++ b/src/x86/kernel.c
@@ -12,25 +12,5 @@ void kernel_main()
     idt_initialize();
     display_initialize();
 
-    // Send a power-on reset sequence to the keyboard controller to ensure that the keyboard is in a known state.
-    io_outb(0x60, 0xff);
-
-    const char* hello = "Hello, world! ";
-
-    for (unsigned i = 0; i < 5; i++)
-    {
-        console_write_string(hello);
-        console_write_uint(i);
-        console_write_string("\n");
-    }
-
-    for (int i = -5; i < 10; i++)
-    {
-        console_write_string(hello);
-        console_write_int(i);
-        console_write_string("\n");
-    }
-
-    display_set_cursor_position(0, VGA_HEIGHT - 1);
-    console_write_string("bye");
+    while (1);
 }


### PR DESCRIPTION
This pull request includes the following updates and improvements related to the Programmable Interrupt Controller (PIC) and the x86 kernel:

- **Feature**: Added keyboard interrupt handling, including a default interrupt handler, mapped through the Interrupt Descriptor Table (IDT), and enabled interrupts in the kernel.
- **Fix**: Ensured interrupts no longer overwrite context registers by replacing individual exception handlers with a generic kernel panic handler and an unused interrupt handler.
- **Documentation updates**:
  - Explained PIC remapping and its significance in avoiding conflicts with CPU exception handlers in the IDT.
  - Detailed the setup of `_start` for initializing the master PIC and added information about IDT configuration for handling keyboard interrupts.
  - Created `pic.md` with comprehensive information on PIC handling operations in x86 systems.
  - Fixed the README link to point correctly to the PIC documentation.