### PR TITLE
refactor(kernel/idt): interrupt management via modular functions

### DIFF
--- a/src/x86/idt/idt.asm
+++ b/src/x86/idt/idt.asm
@@ -61,3 +61,15 @@ idt_handle_kernel_panic:
     popad
     sti
     iret
+
+; This function sets the interrupt flag, allowing the CPU to respond to hardware interrupts.
+global enable_interrupts
+enable_interrupts:
+    sti
+    ret
+
+; This function clears the interrupt flag, preventing the CPU from responding to hardware interrupts.
+global disable_interrupts
+disable_interrupts:
+    cli
+    ret

--- a/src/x86/idt/idt.h
+++ b/src/x86/idt/idt.h
@@ -107,4 +107,14 @@ typedef enum : unsigned
  */
 void idt_initialize(void);
 
+/**
+ * @brief Enables hardware interrupts.
+ */
+void enable_interrupts(void);
+
+/**
+ * @brief Disables hardware interrupts.
+ */
+void disable_interrupts(void);
+
 #endif //IDT_H

--- a/src/x86/kernel.asm
+++ b/src/x86/kernel.asm
@@ -39,9 +39,6 @@ _start:
     mov al, 00000001b
     out 0x21, al;
 
-    ; Enable interrupts
-    sti
-
     call CODE_SEG:kernel_main
 
     ; Do nothing more, enter an infinite loop.

--- a/src/x86/kernel.c
+++ b/src/x86/kernel.c
@@ -11,7 +11,10 @@
 void kernel_main()
 {
     display_initialize();
+
     idt_initialize();
+    enable_interrupts();
+
     if (kernel_heap_init() < 0)
         goto kernel_init_failed;
 


### PR DESCRIPTION
This pull request introduces `enable_interrupts` and `disable_interrupts` functions in both assembly and header files to manage the CPU interrupt flag, improving modularity and readability.

Inline interrupt management code has been replaced with these functions, and `kernel_main` has been updated to use the new `enable_interrupts` function.