### PR TITLE
fix(bootloader): change global label naming in kernel.asm

### DIFF
--- a/src/x86/kernel.asm
+++ b/src/x86/kernel.asm
@@ -1,5 +1,5 @@
 [BITS 32]
-global_start
+global _start
 extern kernel_main
 
 CODE_SEG equ 0x08


### PR DESCRIPTION
## Overview
This PR fixes a mistake in the `kernel.asm` file where a space between `global` keywork and `_start` section was missing.